### PR TITLE
Upgrade RDF4J, support for additional databases, misc fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,27 +38,27 @@
     <dependency>
     	<groupId>commons-logging</groupId>
     	<artifactId>commons-logging</artifactId>
-    	<version>1.1.2</version>
+    	<version>1.2</version>
     </dependency>
     <dependency>
     	<groupId>mysql</groupId>
     	<artifactId>mysql-connector-java</artifactId>
-    	<version>5.1.25</version>
+    	<version>8.0.11</version>
     </dependency>
    <dependency>
-	     <groupId>postgresql</groupId>
+	     <groupId>org.postgresql</groupId>
 	     <artifactId>postgresql</artifactId>
-	     <version>9.1-901.jdbc4</version>
+	     <version>42.2.2</version>
     </dependency>
     <dependency>
     	<groupId>com.h2database</groupId>
     	<artifactId>h2</artifactId>
-    	<version>1.4.184</version>
+    	<version>1.4.197</version>
    	</dependency>
     <dependency>
     	<groupId>commons-cli</groupId>
     	<artifactId>commons-cli</artifactId>
-    	<version>1.2</version>
+    	<version>1.4</version>
     </dependency>
     <dependency>
         <groupId>org.eclipse.rdf4j</groupId>
@@ -75,7 +75,7 @@
     <dependency>
     	<groupId>org.slf4j</groupId>
     	<artifactId>slf4j-simple</artifactId>
-    	<version>1.6.1</version>
+    	<version>1.7.25</version>
     	<type>jar</type>
     	<scope>runtime</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <rdf4j.version>2.3.2</rdf4j.version>
   </properties>
   
   <dependencies>
@@ -63,15 +64,34 @@
     <dependency>
         <groupId>org.eclipse.rdf4j</groupId>
         <artifactId>rdf4j-sail-nativerdf</artifactId>
-        <version>2.3.2</version>
+        <version>${rdf4j.version}</version>
         <scope>compile</scope>
     </dependency>
     <dependency>
         <groupId>org.eclipse.rdf4j</groupId>
-        <artifactId>rdf4j-runtime</artifactId>
-        <version>2.3.2</version>
+        <artifactId>rdf4j-sail-memory</artifactId>
+        <version>${rdf4j.version}</version>
         <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-repository-http</artifactId>
+      <version>${rdf4j.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-repository-sail</artifactId>
+      <version>${rdf4j.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-nquads</artifactId>
+      <version>${rdf4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <dependency>
     	<groupId>org.slf4j</groupId>
     	<artifactId>slf4j-simple</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,16 +61,16 @@
     	<version>1.2</version>
     </dependency>
     <dependency>
-        <groupId>org.openrdf.sesame</groupId>
-        <artifactId>sesame-sail-nativerdf</artifactId>
-        <version>2.6.10</version>
-        <scope>compile</scope>        
+        <groupId>org.eclipse.rdf4j</groupId>
+        <artifactId>rdf4j-sail-nativerdf</artifactId>
+        <version>2.3.2</version>
+        <scope>compile</scope>
     </dependency>
     <dependency>
-    	<groupId>org.openrdf.sesame</groupId>
-    	<artifactId>sesame-runtime</artifactId>
-    	<version>2.6.10</version>
-        <scope>compile</scope>    	
+        <groupId>org.eclipse.rdf4j</groupId>
+        <artifactId>rdf4j-runtime</artifactId>
+        <version>2.3.2</version>
+        <scope>compile</scope>
     </dependency>
     <dependency>
     	<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <rdf4j.version>2.3.2</rdf4j.version>
   </properties>
   

--- a/src/main/java/net/antidot/semantic/rdf/model/impl/sesame/SemiStatement.java
+++ b/src/main/java/net/antidot/semantic/rdf/model/impl/sesame/SemiStatement.java
@@ -29,25 +29,25 @@
  */
 package net.antidot.semantic.rdf.model.impl.sesame;
 
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
 
 public class SemiStatement {
 	
-	private URI p;
+	private IRI p;
 	private Value o;
 	
-	public SemiStatement(URI p, Value o){
+	public SemiStatement(IRI p, Value o){
 		this.p = p;
 		this.o = o;
 	}
 	
 	
-	public URI getPredicate() {
+	public IRI getPredicate() {
 		return p;
 	}
 
-	public void setPredicate(URI p) {
+	public void setPredicate(IRI p) {
 		this.p = p;
 	}
 

--- a/src/main/java/net/antidot/semantic/rdf/model/impl/sesame/SesameDataSet.java
+++ b/src/main/java/net/antidot/semantic/rdf/model/impl/sesame/SesameDataSet.java
@@ -46,30 +46,30 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openrdf.model.BNode;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.GraphQuery;
-import org.openrdf.query.TupleQuery;
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.repository.RepositoryResult;
-import org.openrdf.repository.http.HTTPRepository;
-import org.openrdf.repository.sail.SailRepository;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.rio.RDFParseException;
-import org.openrdf.rio.RDFWriter;
-import org.openrdf.rio.Rio;
-import org.openrdf.sail.inferencer.fc.ForwardChainingRDFSInferencer;
-import org.openrdf.sail.memory.MemoryStore;
-import org.openrdf.sail.nativerdf.NativeStore;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.RepositoryResult;
+import org.eclipse.rdf4j.repository.http.HTTPRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingRDFSInferencer;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 
 public class SesameDataSet {
 
@@ -189,7 +189,8 @@ public class SesameDataSet {
 	 *            uri representing the type (generally xsd)
 	 * @return
 	 */
-	public org.openrdf.model.Literal Literal(String s, URI typeuri) {
+	public org.eclipse.rdf4j.model.Literal Literal(String s, IRI typeuri)
+	{
 		try {
 			RepositoryConnection con = currentRepository.getConnection();
 			try {
@@ -215,7 +216,8 @@ public class SesameDataSet {
 	 *            the literal
 	 * @return
 	 */
-	public org.openrdf.model.Literal Literal(String s) {
+	public org.eclipse.rdf4j.model.Literal Literal(String s)
+	{
 		return Literal(s, null);
 	}
 
@@ -225,12 +227,12 @@ public class SesameDataSet {
 	 * @param uri
 	 * @return
 	 */
-	public URI URIref(String uri) {
+	public IRI URIref(String uri) {
 		try {
 			RepositoryConnection con = currentRepository.getConnection();
 			try {
 				ValueFactory vf = con.getValueFactory();
-				return vf.createURI(uri);
+				return vf.createIRI(uri);
 			} finally {
 				con.close();
 			}
@@ -272,7 +274,7 @@ public class SesameDataSet {
 	 * @param contexts
 	 *            varArgs context objects (use default graph if null)
 	 */
-	public void add(Resource s, URI p, Value o, Resource... contexts) {
+	public void add(Resource s, IRI p, Value o, Resource... contexts) {
 		if (log.isDebugEnabled())
 			log.debug("[SesameDataSet:add] Add triple (" + s.stringValue()
 					+ ", " + p.stringValue() + ", " + o.stringValue() + ").");
@@ -294,7 +296,7 @@ public class SesameDataSet {
 		}
 	}
 
-	public void remove(Resource s, URI p, Value o, Resource... context) {
+	public void remove(Resource s, IRI p, Value o, Resource... context) {
 		try {
 			RepositoryConnection con = currentRepository.getConnection();
 			try {
@@ -471,7 +473,7 @@ public class SesameDataSet {
 	 *            varArgs contexts (use default graph if null)
 	 * @return serialized graph of results
 	 */
-	public List<Statement> tuplePattern(Resource s, URI p, Value o,
+	public List<Statement> tuplePattern(Resource s, IRI p, Value o,
 			Resource... contexts) {
 		try {
 			RepositoryConnection con = currentRepository.getConnection();
@@ -506,7 +508,7 @@ public class SesameDataSet {
 			RepositoryConnection con = currentRepository.getConnection();
 			try {
 				GraphQuery query = con.prepareGraphQuery(
-						org.openrdf.query.QueryLanguage.SPARQL, qs);
+						org.eclipse.rdf4j.query.QueryLanguage.SPARQL, qs);
 				StringWriter stringout = new StringWriter();
 				RDFWriter w = Rio.createWriter(format, stringout);
 				query.evaluate(w);
@@ -532,7 +534,7 @@ public class SesameDataSet {
 			RepositoryConnection con = currentRepository.getConnection();
 			try {
 				TupleQuery query = con.prepareTupleQuery(
-						org.openrdf.query.QueryLanguage.SPARQL, qs);
+						org.eclipse.rdf4j.query.QueryLanguage.SPARQL, qs);
 				TupleQueryResult qres = query.evaluate();
 				ArrayList<HashMap<String, Value>> reslist = new ArrayList<HashMap<String, Value>>();
 				while (qres.hasNext()) {

--- a/src/main/java/net/antidot/semantic/rdf/model/tools/RDFDataValidator.java
+++ b/src/main/java/net/antidot/semantic/rdf/model/tools/RDFDataValidator.java
@@ -32,8 +32,8 @@ import java.util.MissingResourceException;
 
 import net.antidot.semantic.xmls.xsd.XSDType;
 
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.impl.ValueFactoryImpl;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.ValueFactoryImpl;
 
 public abstract class RDFDataValidator {
 	

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/commons/SQLToXMLS.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/commons/SQLToXMLS.java
@@ -60,6 +60,7 @@ public abstract class SQLToXMLS {
 		equivalentTypes.put(SQLType.VARCHAR, XSDType.STRING);
 		equivalentTypes.put(SQLType.CHAR, XSDType.STRING);
 		equivalentTypes.put(SQLType.STRING, XSDType.STRING);
+		equivalentTypes.put(SQLType.NVARCHAR, XSDType.STRING);
 	}
 	
 	public static XSDType getEquivalentType(SQLType sqlType){

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/commons/SpecificSQLToXMLS.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/commons/SpecificSQLToXMLS.java
@@ -187,6 +187,7 @@ public abstract class SpecificSQLToXMLS {
 		equivalentTypes.put(SQLType.CHAR, XSDType.STRING);
 		equivalentTypes.put(SQLType.VARCHAR, XSDType.STRING);
 		equivalentTypes.put(SQLType.STRING, XSDType.STRING);
+		equivalentTypes.put(SQLType.NVARCHAR, XSDType.STRING);
 		equivalentTypes.put(SQLType.UNKNOWN, XSDType.STRING);
 		
 		

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/dm/core/DirectMapper.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/dm/core/DirectMapper.java
@@ -41,7 +41,7 @@ import net.antidot.sql.model.db.Tuple;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openrdf.model.Statement;
+import org.eclipse.rdf4j.model.Statement;
 
 
 public abstract class DirectMapper extends Thread {

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/dm/core/DirectMappingEngine.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/dm/core/DirectMappingEngine.java
@@ -39,7 +39,7 @@ import net.antidot.sql.model.core.DriverType;
 import net.antidot.sql.model.db.Key;
 import net.antidot.sql.model.db.Tuple;
 
-import org.openrdf.model.Statement;
+import org.eclipse.rdf4j.model.Statement;
 
 
 public interface DirectMappingEngine {

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/main/Db2triples.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/main/Db2triples.java
@@ -49,7 +49,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openrdf.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFFormat;
 
 @SuppressWarnings("static-access")
 public class Db2triples {

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLEngine.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLEngine.java
@@ -1041,7 +1041,8 @@ public class R2RMLEngine {
 		if(R2RMLProcessor.getDriverType().equals(DriverType.H2)  
 				|| R2RMLProcessor.getDriverType().equals(DriverType.MSSQL)
 				|| R2RMLProcessor.getDriverType().equals(DriverType.DB2)
-				|| R2RMLProcessor.getDriverType().getDriverName().contains("oracle"))
+				|| R2RMLProcessor.getDriverType().getDriverName().contains("oracle")
+				|| R2RMLProcessor.getDriverType().equals(DriverType.HANA))
 			return conn.createStatement();
 		else
 			return conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLEngine.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLEngine.java
@@ -39,6 +39,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+
 import net.antidot.semantic.rdf.model.impl.sesame.SesameDataSet;
 import net.antidot.semantic.rdf.model.tools.RDFDataValidator;
 import net.antidot.semantic.rdf.rdb2rdf.commons.SQLToXMLS;
@@ -63,16 +73,6 @@ import net.antidot.sql.model.db.ColumnIdentifierImpl;
 import net.antidot.sql.model.tools.SQLToolkit;
 import net.antidot.sql.model.type.SQLType;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.openrdf.model.BNode;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.impl.ValueFactoryImpl;
-
 public class R2RMLEngine {
 
 	// Log
@@ -93,7 +93,7 @@ public class R2RMLEngine {
 	private Map<TermMap, Map<Integer, Value>> sameGeneratedRDFTerm;
 
 	// Value factory
-	private static ValueFactory vf = new ValueFactoryImpl();
+	private static ValueFactory vf = SimpleValueFactory.getInstance();
 
 	public R2RMLEngine(Connection conn) {
 		super();
@@ -189,7 +189,7 @@ public class R2RMLEngine {
 		rows = constructLogicalTable(triplesMap);
 		meta = extractMetaDatas(rows);
 		// 3. Let classes be the class IRIs of sm
-		Set<URI> classes = sm.getClassIRIs();
+		Set<IRI> classes = sm.getClassIRIs();
 		// 4. Let sgm be the set of graph maps of sm
 		Set<GraphMap> sgm = sm.getGraphMaps();
 		// 5. For each logical table row in rows, apply the following method
@@ -341,10 +341,10 @@ public class R2RMLEngine {
 		// 4. Let predicates be the set of generated RDF terms that result from
 		// applying each of the predicate-object map's predicate maps to
 		// child_row
-		Set<URI> predicates = new HashSet<URI>();
+		Set<IRI> predicates = new HashSet<IRI>();
 		for (PredicateMap pm : predicateObjectMap.getPredicateMaps()) {
 			Map<ColumnIdentifier, byte[]> pmFromRow = applyValueToChildRow(pm, n);
-			URI predicate = (URI) extractValueFromTermMap(pm, pmFromRow,
+			IRI predicate = (IRI) extractValueFromTermMap(pm, pmFromRow,
 					triplesMap);
 			log.debug("[R2RMLEngine:generateRDFTriplesFromReferencingRow] Generate predicate : "
 					+ predicate);
@@ -359,10 +359,10 @@ public class R2RMLEngine {
 				+ object);
 		// 6. Let subject_graphs be the set of generated RDF terms that result
 		// from applying each graph map of sgm to child_row
-		Set<URI> subject_graphs = new HashSet<URI>();
+		Set<IRI> subject_graphs = new HashSet<IRI>();
 		for (GraphMap graphMap : sgm) {
 			Map<ColumnIdentifier, byte[]> sgmFromRow = applyValueToChildRow(graphMap, n);
-			URI subject_graph = (URI) extractValueFromTermMap(graphMap,
+			IRI subject_graph = (IRI) extractValueFromTermMap(graphMap,
 					sgmFromRow, triplesMap);
 			log.debug("[R2RMLEngine:generateRDFTriplesFromReferencingRow] Generate subject graph : "
 					+ subject_graph);
@@ -370,10 +370,10 @@ public class R2RMLEngine {
 		}
 		// 7. Let predicate-object_graphs be the set of generated RDF terms
 		// that result from applying each graph map in pogm to child_row
-		Set<URI> predicate_object_graphs = new HashSet<URI>();
+		Set<IRI> predicate_object_graphs = new HashSet<IRI>();
 		for (GraphMap graphMap : pogm) {
 			Map<ColumnIdentifier, byte[]> pogmFromRow = applyValueToChildRow(graphMap, n);
-			URI predicate_object_graph = (URI) extractValueFromTermMap(
+			IRI predicate_object_graph = (IRI) extractValueFromTermMap(
 					graphMap, pogmFromRow, triplesMap);
 			log.debug("[R2RMLEngine:generateRDFTriplesFromReferencingRow] Generate predicate object graph : "
 					+ predicate_object_graph);
@@ -381,10 +381,11 @@ public class R2RMLEngine {
 		}
 		// 8. For each predicate in predicates, add triples to the output
 		// dataset
-		for (URI predicate : predicates) {
+		for (IRI predicate : predicates)
+		{
 			// If neither sgm nor pogm has any graph maps: rr:defaultGraph;
 			// otherwise: union of subject_graphs and predicate-object_graphs
-			Set<URI> targetGraphs = new HashSet<URI>();
+			Set<IRI> targetGraphs = new HashSet<IRI>();
 			targetGraphs.addAll(subject_graphs);
 			targetGraphs.addAll(predicate_object_graphs);
 			addTriplesToTheOutputDataset(sesameDataSet, subject, predicate,
@@ -473,7 +474,7 @@ public class R2RMLEngine {
 	}
 
 	private void generateRDFTriplesFromRow(SesameDataSet sesameDataSet,
-			TriplesMap triplesMap, SubjectMap sm, Set<URI> classes,
+			TriplesMap triplesMap, SubjectMap sm, Set<IRI> classes,
 			Set<GraphMap> sgm) throws SQLException, R2RMLDataError,
 			UnsupportedEncodingException {
 
@@ -491,18 +492,19 @@ public class R2RMLEngine {
 
 		// 2. Let subject_graphs be the set of the generated RDF terms
 		// that result from applying each term map in sgm to row
-		Set<URI> subject_graphs = new HashSet<URI>();
+		Set<IRI> subject_graphs = new HashSet<IRI>();
 		for (GraphMap graphMap : sgm) {
 			Map<ColumnIdentifier, byte[]> sgmFromRow = applyValueToRow(graphMap);
-			URI subject_graph = (URI) extractValueFromTermMap(graphMap,
+			IRI subject_graph = (IRI) extractValueFromTermMap(graphMap,
 					sgmFromRow, triplesMap);
 			log.debug("[R2RMLEngine:genereateRDFTriplesFromRow] Generate subject graph : "
 					+ subject_graph);
 			subject_graphs.add(subject_graph);
 		}
 		// 3. For each classIRI in classes, add triples to the output dataset
-		for (URI classIRI : sm.getClassIRIs()) {
-			URI predicate = vf.createURI(R2RMLVocabulary.RDF_NAMESPACE
+		for (IRI classIRI : sm.getClassIRIs())
+		{
+			IRI predicate = vf.createIRI(R2RMLVocabulary.RDF_NAMESPACE
 					+ R2RMLTerm.TYPE);
 			addTriplesToTheOutputDataset(sesameDataSet, subject, predicate,
 					classIRI, subject_graphs);
@@ -575,13 +577,13 @@ public class R2RMLEngine {
 
 	private void generateRDFTriplesFromPredicateObjectMap(
 			SesameDataSet sesameDataSet, TriplesMap triplesMap,
-			Resource subject, Set<URI> subjectGraphs,
+			Resource subject, Set<IRI> subjectGraphs,
 			PredicateObjectMap predicateObjectMap) throws SQLException,
 			R2RMLDataError, UnsupportedEncodingException {
 		// 1. Let predicates be the set of generated RDF terms that result
 		// from applying each of the predicate-object map's predicate maps to
 		// row
-		Set<URI> predicates = new HashSet<URI>();
+		Set<IRI> predicates = new HashSet<IRI>();
 		for (PredicateMap pm : predicateObjectMap.getPredicateMaps()) {
 			Map<ColumnIdentifier, byte[]> pmFromRow = applyValueToRow(pm);
 			boolean nullFound = false;
@@ -593,7 +595,7 @@ public class R2RMLEngine {
 				}
 			if (nullFound)
 				continue;
-			URI predicate = (URI) extractValueFromTermMap(pm, pmFromRow,
+			IRI predicate = (IRI) extractValueFromTermMap(pm, pmFromRow,
 					triplesMap);
 			log.debug("[R2RMLEngine:genereateRDFTriplesFromRow] Generate predicate : "
 					+ predicate);
@@ -624,13 +626,13 @@ public class R2RMLEngine {
 		Set<GraphMap> pogm = predicateObjectMap.getGraphMaps();
 		// 4. Let predicate-object_graphs be the set of generated RDF
 		// terms that result from applying each graph map in pogm to row
-		Set<URI> predicate_object_graphs = new HashSet<URI>();
+		Set<IRI> predicate_object_graphs = new HashSet<IRI>();
 		// 4+. Add graph of subject graphs set
 		if (subjectGraphs != null)
 			predicate_object_graphs.addAll(subjectGraphs);
 		for (GraphMap graphMap : pogm) {
 			Map<ColumnIdentifier, byte[]> pogmFromRow = applyValueToRow(graphMap);
-			URI predicate_object_graph = (URI) extractValueFromTermMap(
+			IRI predicate_object_graph = (IRI) extractValueFromTermMap(
 					graphMap, pogmFromRow, triplesMap);
 			log.debug("[R2RMLEngine:genereateRDFTriplesFromRow] Generate predicate object graph : "
 					+ predicate_object_graph);
@@ -640,7 +642,8 @@ public class R2RMLEngine {
 		// is a member
 		// of predicates and object is a member of objects,
 		// add triples to the output dataset
-		for (URI predicate : predicates) {
+		for (IRI predicate : predicates)
+		{
 			for (Value object : objects) {
 				addTriplesToTheOutputDataset(sesameDataSet, subject, predicate,
 						object, predicate_object_graphs);
@@ -660,7 +663,8 @@ public class R2RMLEngine {
 	 * @param targetGraphs
 	 */
 	private void addTriplesToTheOutputDataset(SesameDataSet sesameDataSet,
-			Resource subject, URI predicate, Value object, Set<URI> targetGraphs) {
+			Resource subject, IRI predicate, Value object, Set<IRI> targetGraphs)
+	{
 
 		// 1. If Subject, Predicate or Object is empty, then abort these steps.
 		if (subject == null || predicate == null || object == null)
@@ -673,7 +677,8 @@ public class R2RMLEngine {
 			sesameDataSet.addStatement(triple);
 			log.debug("[R2RMLEngine:addStatement] Added new statement : " + triple);
 		}
-		for (URI targetGraph : targetGraphs) {
+		for (IRI targetGraph : targetGraphs)
+		{
 			if (targetGraph.stringValue().equals(
 					R2RMLVocabulary.R2RML_NAMESPACE + R2RMLTerm.DEFAULT_GRAPH)) {
 				// 3. If the set of target graphs includes rr:defaultGraph,
@@ -761,7 +766,7 @@ public class R2RMLEngine {
 		switch (termMap.getTermType()) {
 		case IRI:
 			// 2. Otherwise, if the term map's term type is rr:IRI
-			URI iri = generateIRITermType(termMap, value);
+				IRI iri = generateIRITermType(termMap, value);
 			log.debug("[R2RMLEngine:generateRDFTerm] Generated IRI RDF Term : "
 					+ iri);
 			return (Value) iri;
@@ -829,8 +834,7 @@ public class R2RMLEngine {
 			// value =
 			// XSDLexicalTransformation.extractNaturalRDFFormFrom(termMap.getDataType(),
 			// value);
-			URI datatype = vf.createURI(termMap.getDataType()
-					.getAbsoluteStringURI());
+			IRI datatype = vf.createIRI(termMap.getDataType().getAbsoluteStringURI());
 			return vf.createLiteral(value, datatype);
 
 		} else {
@@ -855,32 +859,34 @@ public class R2RMLEngine {
 		}
 	}
 
-	private URI generateIRITermType(TermMap termMap, String value)
+	private IRI generateIRITermType(TermMap termMap, String value)
 			throws R2RMLDataError, SQLException {
 		// 1. Let value be the natural RDF lexical form corresponding to value.
 		// 2. If value is a valid absolute IRI [RFC3987], then return an IRI
 		// generated from value.
 
-		if (RDFDataValidator.isValidURI(value)) {
-			URI result = vf.createURI(value);
+		if (RDFDataValidator.isValidURI(value))
+		{
+			IRI result = vf.createIRI(value);
 			log.debug("[R2RMLEngine:generateIRITermType] Valid generated IRI : "
 					+ value);
 			return result;
 		} else {
 			String prependedValue = baseIRI + value;
-			if (RDFDataValidator.isValidURI(prependedValue)) {
+			if (RDFDataValidator.isValidURI(prependedValue))
+			{
 				// Otherwise, prepend value with the base IRI. If the result is
 				// a valid absolute IRI [RFC3987], then return an IRI generated
 				// from the result.
 				log.debug("[R2RMLEngine:generateIRITermType] Valid generated IRI : "
 						+ prependedValue);
-				URI result = vf.createURI(prependedValue);
+				IRI result = vf.createIRI(prependedValue);
 				return result;
 			} else {
 				// 4. Otherwise, raise a data error.
 				throw new R2RMLDataError(
-						"[R2RMLEngine:generateIRITermType] This relative URI "
-								+ value + " or this absolute URI " + baseIRI
+						"[R2RMLEngine:generateIRITermType] This relative IRI " + value + " or this absolute IRI "
+								+ baseIRI
 								+ value + " is not valid.");
 			}
 		}
@@ -942,7 +948,7 @@ public class R2RMLEngine {
 			// typed literal whose datatype IRI is the IRI indicated in the
 			// RDF
 			return vf.createLiteral(value,
-					vf.createURI(xsdType.getAbsoluteStringURI()));
+					vf.createIRI(xsdType.getAbsoluteStringURI()));
 		} else {
 			// 4. Otherwise, the result is a plain literal without language
 			// tag whose lexical form is the SQL data value CAST TO STRING.

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLEngine.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLEngine.java
@@ -1021,7 +1021,8 @@ public class R2RMLEngine {
 	private byte[] getBytes(ResultSet rs, int m) throws SQLException {
 		byte[] value = null;
 		if(R2RMLProcessor.getDriverType().equals(DriverType.H2)  
-				|| R2RMLProcessor.getDriverType().equals(DriverType.MSSQL)
+				|| (R2RMLProcessor.getDriverType().equals(DriverType.MSSQL) || R2RMLProcessor.getDriverType()
+						.getDriverName().equals("com.microsoft.sqlserver.jdbc.SQLServerDriver"))
 				|| R2RMLProcessor.getDriverType().equals(DriverType.DB2)
 				|| R2RMLProcessor.getDriverType().equals(DriverType.TERADATA)
 				|| R2RMLProcessor.getDriverType().getDriverName().contains("EXADriver")
@@ -1039,7 +1040,8 @@ public class R2RMLEngine {
 	
 	private java.sql.Statement createStatement() throws SQLException {
 		if(R2RMLProcessor.getDriverType().equals(DriverType.H2)  
-				|| R2RMLProcessor.getDriverType().equals(DriverType.MSSQL)
+				|| (R2RMLProcessor.getDriverType().equals(DriverType.MSSQL) || R2RMLProcessor.getDriverType()
+						.getDriverName().equals("com.microsoft.sqlserver.jdbc.SQLServerDriver"))
 				|| R2RMLProcessor.getDriverType().equals(DriverType.DB2)
 				|| R2RMLProcessor.getDriverType().getDriverName().contains("oracle")
 				|| R2RMLProcessor.getDriverType().equals(DriverType.HANA))

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLEngine.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLEngine.java
@@ -1023,6 +1023,8 @@ public class R2RMLEngine {
 		if(R2RMLProcessor.getDriverType().equals(DriverType.H2)  
 				|| R2RMLProcessor.getDriverType().equals(DriverType.MSSQL)
 				|| R2RMLProcessor.getDriverType().equals(DriverType.DB2)
+				|| R2RMLProcessor.getDriverType().equals(DriverType.TERADATA)
+				|| R2RMLProcessor.getDriverType().getDriverName().contains("EXADriver")
 				|| R2RMLProcessor.getDriverType().getDriverName().contains("oracle")) {
 			// see e.g. https://groups.google.com/forum/#!topic/h2-database/ZIQMelu7zG8
 			

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLProcessor.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/core/R2RMLProcessor.java
@@ -40,8 +40,8 @@ import net.antidot.sql.model.core.DriverType;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.rio.RDFParseException;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.rio.RDFParseException;
 
 public abstract class R2RMLProcessor {
 	

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/AbstractTermMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/AbstractTermMap.java
@@ -446,7 +446,7 @@ public abstract class AbstractTermMap implements TermMap {
 				throw new IllegalStateException(
 						"[AbstractTermMap:getValue] impossible to extract from an empty database value set.");
 			result = R2RMLToolkit.extractColumnValueFromStringTemplate(
-					stringTemplate, dbValues, dbTypes);
+					stringTemplate, dbValues, dbTypes, termType);
 			return result;
 
 		default:

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/AbstractTermMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/AbstractTermMap.java
@@ -404,6 +404,14 @@ public abstract class AbstractTermMap implements TermMap {
 				throw new IllegalStateException(
 						"[AbstractTermMap:getValue] impossible to extract from an empty database value set.");
 			byte[] bytesResult = dbValues.get(columnValue);
+			// fallback: check in case-insensitive way (see official test suite executed with H2)
+			if(bytesResult==null) {
+				for(ColumnIdentifier colId : dbValues.keySet()) {
+					if(colId.toString().equalsIgnoreCase(columnValue.toString())) {
+						bytesResult = dbValues.get(colId);
+					}
+				}
+			}
 			/* Extract the SQLType in dbValues from the key which is
 			 * equals to "columnValue" */
 			SQLType sqlType = null;			
@@ -412,7 +420,14 @@ public abstract class AbstractTermMap implements TermMap {
 				sqlType = colId.getSqlType();
 				break;
 			    }
-			}			    
+			}
+			// fallback: check in case-insensitive way (see official test suite executed with H2)
+			for(ColumnIdentifier colId : dbValues.keySet()) {
+			    if(colId.toString().equalsIgnoreCase(columnValue.toString())) {
+				sqlType = colId.getSqlType();
+				break;
+			    }
+			}
 			// Apply cast to string to the SQL data value
 			String result;
 			if (sqlType != null) {

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/AbstractTermMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/AbstractTermMap.java
@@ -33,6 +33,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+
 import net.antidot.semantic.rdf.model.tools.RDFDataValidator;
 import net.antidot.semantic.rdf.rdb2rdf.commons.SQLToXMLS;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLStructureException;
@@ -43,15 +49,7 @@ import net.antidot.semantic.xmls.xsd.XSDLexicalTransformation;
 import net.antidot.semantic.xmls.xsd.XSDType;
 import net.antidot.sql.model.db.ColumnIdentifier;
 import net.antidot.sql.model.db.ColumnIdentifierImpl;
-import net.antidot.sql.model.tools.SQLDataValidator;
-import net.antidot.sql.model.tools.SQLToolkit;
 import net.antidot.sql.model.type.SQLType;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.openrdf.model.Literal;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
 
 public abstract class AbstractTermMap implements TermMap {
 
@@ -68,8 +66,8 @@ public abstract class AbstractTermMap implements TermMap {
 	private String inverseExpression;
 	private ColumnIdentifier languageColumnValue;
 
-	protected AbstractTermMap(Value constantValue, URI dataType,
-			String languageTag, String stringTemplate, URI termType,
+	protected AbstractTermMap(Value constantValue, IRI dataType,
+			String languageTag, String stringTemplate, IRI termType,
 			String inverseExpression, ColumnIdentifier columnValue, ColumnIdentifier languageColumnValue)
 			throws R2RMLDataError, InvalidR2RMLStructureException,
 			InvalidR2RMLSyntaxException {
@@ -145,7 +143,7 @@ public abstract class AbstractTermMap implements TermMap {
 //							+ "value : " + termType);
 //	}
 
-	protected void setTermType(URI termType, URI dataType)
+	protected void setTermType(IRI termType, IRI dataType)
 			throws InvalidR2RMLSyntaxException, R2RMLDataError,
 			InvalidR2RMLStructureException {
 		if (termType == null) {
@@ -172,7 +170,7 @@ public abstract class AbstractTermMap implements TermMap {
 		}
 	}
 
-	private TermType checkTermType(URI termType)
+	private TermType checkTermType(IRI termType)
 			throws InvalidR2RMLSyntaxException, InvalidR2RMLStructureException,
 			R2RMLDataError {
 		// Its value MUST be an IRI
@@ -264,7 +262,7 @@ public abstract class AbstractTermMap implements TermMap {
 	 * 
 	 * @throws R2RMLDataError
 	 */
-	public void checkDataType(URI dataType) throws R2RMLDataError {
+	public void checkDataType(IRI dataType) throws R2RMLDataError {
 		// Its value MUST be an IRI
 		if (!RDFDataValidator.isValidDatatype(dataType.stringValue()))
 			throw new R2RMLDataError(
@@ -272,7 +270,7 @@ public abstract class AbstractTermMap implements TermMap {
 							+ dataType);
 	}
 
-	public void setDataType(URI dataType) throws R2RMLDataError,
+	public void setDataType(IRI dataType) throws R2RMLDataError,
 			InvalidR2RMLStructureException {
 		if (!isTypeable() && dataType != null)
 			throw new InvalidR2RMLStructureException(

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdGraphMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdGraphMap.java
@@ -29,21 +29,21 @@
  ****************************************************************************/
 package net.antidot.semantic.rdf.rdb2rdf.r2rml.model;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+
 import net.antidot.semantic.rdf.model.tools.RDFDataValidator;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLStructureException;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLSyntaxException;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.R2RMLDataError;
 import net.antidot.sql.model.db.ColumnIdentifier;
 
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-
 public class StdGraphMap extends AbstractTermMap implements GraphMap {
 
 
 	public StdGraphMap(Value constantValue,
 			String stringTemplate, String inverseExpression,
-			ColumnIdentifier columnValue, URI termType) throws R2RMLDataError,
+			ColumnIdentifier columnValue, IRI termType) throws R2RMLDataError,
 			InvalidR2RMLStructureException, InvalidR2RMLSyntaxException {
 		// No Literal term type
 		// ==> No datatype

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdObjectMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdObjectMap.java
@@ -27,22 +27,22 @@ package net.antidot.semantic.rdf.rdb2rdf.r2rml.model;
 
 import java.util.HashSet;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+
 import net.antidot.semantic.rdf.model.tools.RDFDataValidator;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLStructureException;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLSyntaxException;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.R2RMLDataError;
 import net.antidot.sql.model.db.ColumnIdentifier;
 
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-
 public class StdObjectMap extends AbstractTermMap implements TermMap, ObjectMap {
 
 	private PredicateObjectMap predicateObjectMap;
 
 	public StdObjectMap(PredicateObjectMap predicateObjectMap,
-			Value constantValue, URI dataType, String languageTag,
-			String stringTemplate, URI termType, String inverseExpression,
+			Value constantValue, IRI dataType, String languageTag, String stringTemplate, IRI termType,
+			String inverseExpression,
 			ColumnIdentifier columnValue, ColumnIdentifier languageColumnValue) throws R2RMLDataError,
 			InvalidR2RMLStructureException, InvalidR2RMLSyntaxException {
 		super(constantValue, dataType, languageTag, stringTemplate, termType,

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdPredicateMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdPredicateMap.java
@@ -27,14 +27,14 @@ package net.antidot.semantic.rdf.rdb2rdf.r2rml.model;
 
 import java.util.HashSet;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+
 import net.antidot.semantic.rdf.model.tools.RDFDataValidator;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLStructureException;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLSyntaxException;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.R2RMLDataError;
 import net.antidot.sql.model.db.ColumnIdentifier;
-
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
 
 public class StdPredicateMap extends AbstractTermMap implements TermMap,
 		PredicateMap {
@@ -43,7 +43,7 @@ public class StdPredicateMap extends AbstractTermMap implements TermMap,
 
 	public StdPredicateMap(PredicateObjectMap predicateObjectMap,
 			Value constantValue, String stringTemplate,
-			String inverseExpression, ColumnIdentifier columnValue, URI termType)
+			String inverseExpression, ColumnIdentifier columnValue, IRI termType)
 			throws R2RMLDataError, InvalidR2RMLStructureException,
 			InvalidR2RMLSyntaxException {
 		// No Literal term type

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdSubjectMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdSubjectMap.java
@@ -31,24 +31,24 @@ package net.antidot.semantic.rdf.rdb2rdf.r2rml.model;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+
 import net.antidot.semantic.rdf.model.tools.RDFDataValidator;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLStructureException;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLSyntaxException;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.R2RMLDataError;
 import net.antidot.sql.model.db.ColumnIdentifier;
 
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-
 public class StdSubjectMap extends AbstractTermMap implements SubjectMap {
 
-	private Set<URI> classIRIs;
+	private Set<IRI> classIRIs;
 	private HashSet<GraphMap> graphMaps;
 	protected TriplesMap ownTriplesMap;
 
 	public StdSubjectMap(TriplesMap ownTriplesMap, Value constantValue,
-			String stringTemplate, URI termType, String inverseExpression,
-			ColumnIdentifier columnValue, Set<URI> classIRIs, Set<GraphMap> graphMaps)
+			String stringTemplate, IRI termType, String inverseExpression,
+			ColumnIdentifier columnValue, Set<IRI> classIRIs, Set<GraphMap> graphMaps)
 			throws R2RMLDataError, InvalidR2RMLStructureException,
 			InvalidR2RMLSyntaxException {
 		// No Literal term type
@@ -81,17 +81,17 @@ public class StdSubjectMap extends AbstractTermMap implements SubjectMap {
 			this.graphMaps.addAll(graphMaps);
 	}
 
-	private void setClassIRIs(Set<URI> classIRIs2) throws R2RMLDataError {
-		this.classIRIs = new HashSet<URI>();
+	private void setClassIRIs(Set<IRI> classIRIs2) throws R2RMLDataError {
+		this.classIRIs = new HashSet<IRI>();
 		if (classIRIs2 != null) {
 			checkClassIRIs(classIRIs);
 			classIRIs.addAll(classIRIs2);
 		}
 	}
 
-	private void checkClassIRIs(Set<URI> classIRIs2) throws R2RMLDataError {
+	private void checkClassIRIs(Set<IRI> classIRIs2) throws R2RMLDataError {
 		// The values of the rr:class property must be IRIs.
-		for (URI classIRI : classIRIs) {
+		for (IRI classIRI : classIRIs) {
 			if (!RDFDataValidator.isValidURI(classIRI.stringValue()))
 				throw new R2RMLDataError(
 						"[AbstractTermMap:checkClassIRIs] Not a valid URI : "
@@ -99,7 +99,7 @@ public class StdSubjectMap extends AbstractTermMap implements SubjectMap {
 		}
 	}
 
-	public Set<URI> getClassIRIs() {
+	public Set<IRI> getClassIRIs() {
 		return classIRIs;
 	}
 
@@ -133,7 +133,7 @@ public class StdSubjectMap extends AbstractTermMap implements SubjectMap {
 
 	public String toString() {
 		String result = super.toString() + " [StdSubjectMap : classIRIs = [";
-		for (URI uri : classIRIs)
+		for (IRI uri : classIRIs)
 			result += uri.getLocalName() + ",";
 		result += "], graphMaps = [";
 		for (GraphMap graphMap : graphMaps)

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/SubjectMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/SubjectMap.java
@@ -28,16 +28,16 @@ package net.antidot.semantic.rdf.rdb2rdf.r2rml.model;
 
 import java.util.Set;
 
-import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLStructureException;
+import org.eclipse.rdf4j.model.IRI;
 
-import org.openrdf.model.URI;
+import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.InvalidR2RMLStructureException;
 
 public interface SubjectMap extends TermMap {
 
 	/**
 	 * A subject map may have one or more class IRIs.
 	 */
-	public Set<URI> getClassIRIs();
+	public Set<IRI> getClassIRIs();
 	
 	/**
 	 * Any subject map may have one or more associated graph maps.

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/TermMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/TermMap.java
@@ -37,7 +37,7 @@ import net.antidot.semantic.xmls.xsd.XSDLexicalTransformation;
 import net.antidot.semantic.xmls.xsd.XSDType;
 import net.antidot.sql.model.db.ColumnIdentifier;
 
-import org.openrdf.model.Value;
+import org.eclipse.rdf4j.model.Value;
 
 public interface TermMap {
 

--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/tools/R2RMLToolkit.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/tools/R2RMLToolkit.java
@@ -39,6 +39,7 @@ import java.util.StringTokenizer;
 
 import net.antidot.semantic.rdf.rdb2rdf.commons.SQLToXMLS;
 import net.antidot.semantic.rdf.rdb2rdf.r2rml.exception.R2RMLDataError;
+import net.antidot.semantic.rdf.rdb2rdf.r2rml.model.TermType;
 import net.antidot.semantic.xmls.xsd.XSDLexicalTransformation;
 import net.antidot.semantic.xmls.xsd.XSDType;
 import net.antidot.sql.model.db.ColumnIdentifier;
@@ -261,7 +262,7 @@ public abstract class R2RMLToolkit {
 	public static String extractColumnValueFromStringTemplate(
 			String stringTemplate,
 			Map<ColumnIdentifier, byte[]> dbValues,
-			ResultSetMetaData dbTypes) throws R2RMLDataError, SQLException,
+			ResultSetMetaData dbTypes, TermType termType) throws R2RMLDataError, SQLException,
 			UnsupportedEncodingException {
 		// Let result be the template string
 
@@ -290,7 +291,11 @@ public abstract class R2RMLToolkit {
 			{
 			    value = new String(byteValue, "UTF-8");
 			}
-			result = column.replaceAll(result, getIRISafeVersion(value));
+			if(termType.equals(TermType.LITERAL)){ //replace only for IRIs with IRISafeVersion
+				result = column.replaceAll(result, value);
+			}else{
+				result = column.replaceAll(result, getIRISafeVersion(value));
+			}
 			// Test backslashes result =
 			/*
 			 * result.replaceAll("\\{\\\"" + column + "\\\"\\}",

--- a/src/main/java/net/antidot/sql/model/core/DriverType.java
+++ b/src/main/java/net/antidot/sql/model/core/DriverType.java
@@ -30,6 +30,7 @@ public class DriverType {
     public static DriverType MSSQL = new DriverType("net.sourceforge.jtds.jdbc.Driver");
     public static DriverType DB2 = new DriverType("com.ibm.db2.jcc.DB2Driver");
     public static DriverType TERADATA = new DriverType("com.teradata.jdbc.TeraDriver");
+	public static DriverType HANA = new DriverType("com.sap.db.jdbc.Driver");
 
 
     private String driverName;

--- a/src/main/java/net/antidot/sql/model/core/DriverType.java
+++ b/src/main/java/net/antidot/sql/model/core/DriverType.java
@@ -29,6 +29,7 @@ public class DriverType {
     public static DriverType Oracle = new DriverType("oracle.jdbc.driver.OracleDriver");
     public static DriverType MSSQL = new DriverType("net.sourceforge.jtds.jdbc.Driver");
     public static DriverType DB2 = new DriverType("com.ibm.db2.jcc.DB2Driver");
+    public static DriverType TERADATA = new DriverType("com.teradata.jdbc.TeraDriver");
 
 
     private String driverName;

--- a/src/main/java/net/antidot/sql/model/core/DriverType.java
+++ b/src/main/java/net/antidot/sql/model/core/DriverType.java
@@ -22,10 +22,14 @@ package net.antidot.sql.model.core;
 
 // JDBC driver types	
 public class DriverType {	    
-    public static DriverType MysqlDriver = new DriverType("com.mysql.jdbc.Driver");
+
+	public static DriverType MysqlDriver = new DriverType("com.mysql.jdbc.Driver");
     public static DriverType PostgreSQL = new DriverType("org.postgresql.Driver");
     public static DriverType H2 = new DriverType("org.h2.Driver");
     public static DriverType Oracle = new DriverType("oracle.jdbc.driver.OracleDriver");
+    public static DriverType MSSQL = new DriverType("net.sourceforge.jtds.jdbc.Driver");
+    public static DriverType DB2 = new DriverType("com.ibm.db2.jcc.DB2Driver");
+
 
     private String driverName;
     

--- a/src/main/java/net/antidot/sql/model/type/SQLType.java
+++ b/src/main/java/net/antidot/sql/model/type/SQLType.java
@@ -61,7 +61,9 @@ public enum SQLType {
 	
 	
 	// Unsupported
-	BLOB(Types.BLOB);
+	BLOB(Types.BLOB),
+	CLOB(Types.CLOB),
+	SQLXML(Types.SQLXML);
 	
 	// Log
 	private static Log log = LogFactory
@@ -155,7 +157,7 @@ public enum SQLType {
 			if (sqlType.getID() == id)
 				return sqlType;
 		}
-		log.warn("[SQLType:getSQLCastQuery] Unkonwm SQL id : " + id);
+		log.warn("[SQLType:getSQLCastQuery] Unkonwn SQL id : " + id);
 		return UNKNOWN;
 	}
 	

--- a/src/main/java/net/antidot/sql/model/type/SQLType.java
+++ b/src/main/java/net/antidot/sql/model/type/SQLType.java
@@ -58,6 +58,7 @@ public enum SQLType {
 	VARCHAR(Types.VARCHAR),
 	STRING(Types.LONGVARCHAR),
 	TINYINT(Types.TINYINT),
+	NVARCHAR(Types.NVARCHAR),
 	
 	
 	// Unsupported
@@ -123,6 +124,7 @@ public enum SQLType {
 		result.add(CHAR);
 		result.add(VARCHAR);
 		result.add(STRING);
+		result.add(NVARCHAR);
 		return result;
 	}
 

--- a/src/test/java/H2.java
+++ b/src/test/java/H2.java
@@ -1,0 +1,126 @@
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import net.antidot.semantic.rdf.model.impl.sesame.SesameDataSet;
+import net.antidot.semantic.rdf.rdb2rdf.r2rml.core.R2RMLProcessor;
+import net.antidot.sql.model.core.DriverType;
+
+
+
+@Ignore
+@RunWith(Parameterized.class)
+public class H2 {
+
+    private static Log log = LogFactory.getLog(H2.class);
+    
+    private static final String baseURI = "http://example.com/base/";
+    
+    private static final String driver = DriverType.H2.toString();
+    
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+	
+    private MainIT.NormTested tested = null;
+    private String directory = null;
+    private String r2rmlSuffix = null;
+
+    public H2(MainIT.NormTested tested, String directory, String suffix)
+	    throws SQLException, InstantiationException,
+	    IllegalAccessException, ClassNotFoundException {
+		this.tested = tested;
+		this.directory = directory;
+		this.r2rmlSuffix = suffix;
+    }
+    
+    @Parameters
+    public static Collection<Object[]> getTestsFiles() throws Exception {
+     return MainIT.getTestsFiles();
+    }
+    
+    @Test
+    public void testNorm() throws Exception {
+    	
+    	Class.forName(driver);
+	    log.info("[W3CTester:testNorm] Run tests for " + tested.name()
+		    + " from : " + directory);
+	    if(tested.equals( MainIT.NormTested.R2RML)){
+	    	testR2RML(this.r2rmlSuffix,this.directory);
+	    }
+    }
+
+	public void testR2RML(String suffix, String directory ) throws Exception{
+		
+		String connString = getFreshH2DatabaseConnection(directory+suffix);
+		String mapped_filepath = directory+ "/mapped" + suffix+ ".nq";	
+		
+		SesameDataSet result;
+		try(Connection conn = getH2DatabaseConnection(connString)){
+			Statement stat = conn.createStatement();
+
+		    stat.execute("runscript from '"+directory+"/create.sql'");
+		    conn.commit();
+		     
+		 	final String test_filepath = directory+ "/r2rml" + suffix+ ".ttl";	
+ 
+		 	File r2rml_def_file = new File(test_filepath);
+		 	try{
+		 		result = R2RMLProcessor.convertDatabase(conn, r2rml_def_file.getAbsolutePath(), baseURI, new DriverType(driver));
+			}	catch (Exception e) {
+	 			if (new File(mapped_filepath).exists()) {
+	 			    e.printStackTrace();
+	 			    fail("R2RML error: " + new File(directory).getName() +"\n Mapping" + test_filepath) ;
+	 			}
+	 			else {
+	 			    log.info("[W3CTester:runR2RML] R2RML data was not valid");
+	 			}
+	 			return;
+ 		    }
+
+ 		    // Serialize result
+ 		    //result.dumpRDF(directory + "/mapped" + suffix+ "-db2triples.nq", RDFFormat.NQUADS);
+
+ 		    // Load ref
+ 		    SesameDataSet ref = new SesameDataSet();
+ 		    try {
+ 		    	ref.loadDataFromFile(mapped_filepath, RDFFormat.NQUADS);
+ 		    }catch (Exception e) {
+ 		    	e.printStackTrace();
+ 		    	fail("Unable to load ref " + mapped_filepath);
+ 		    	return;
+ 		    }
+ 		    
+ 		    // Compare
+ 		    assertTrue("R2RML test failed: " + directory + "- Case: "+suffix, ref.isEqualTo(result));
+		}
+				
+
+	}
+	
+	private Connection getH2DatabaseConnection(String connString) throws Exception{
+		
+        return DriverManager.getConnection(connString) ;
+	}
+	
+	private String getFreshH2DatabaseConnection(String filePath) throws IOException{
+		return "jdbc:h2:file:"+tempFolder.newFolder("temp"+filePath.hashCode()).getAbsolutePath();
+	}
+}

--- a/src/test/java/MainIT.java
+++ b/src/test/java/MainIT.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import org.openrdf.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFFormat;
 
 @Ignore
 @RunWith(Parameterized.class)


### PR DESCRIPTION
This PR updates db2triples to use RDF4j and adds support for additional relational databases. In addition, some smaller fixes are added.

The following issues are addressed: #15, #16, #17, #18, #19 