### PR TITLE
Add MariaDB, update MySQL, remove ojdbc (address #25)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
     	<groupId>mysql</groupId>
     	<artifactId>mysql-connector-java</artifactId>
-    	<version>8.0.11</version>
+    	<version>8.0.16</version>
     </dependency>
    <dependency>
 	     <groupId>org.postgresql</groupId>
@@ -102,12 +102,11 @@
     	<scope>runtime</scope>
     </dependency>
     <dependency>
-    	<groupId>com.github.noraui</groupId>
-    	<artifactId>ojdbc7</artifactId>
-    	<version>12.1.0.2</version>
-    	<type>jar</type>
-    	<scope>runtime</scope>
+		<groupId>org.mariadb.jdbc</groupId>
+		<artifactId>mariadb-java-client</artifactId>
+		<version>2.4.2</version>
     </dependency>
+
     
   </dependencies>
   


### PR DESCRIPTION
The ojdbc is no longer in the public maven repository, and the project does not compile with this dependency in the pom.xml. Whoever needs ojdbc should add it manually to the local repository. 
MySQL driver has updated. The old version linked in the current version db2triples fails on some time zones that have changed since the release. ("`java.sql.SQLException: The server time zone value 'Russia TZ 2 Standard Time' is unrecognized or represents more than one time zone`")
MariaDB has an own jdbc driver, perfectly compatible with db2triples.